### PR TITLE
add molecule verification step

### DIFF
--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,15 @@
+---
+- name: Verify
+  hosts: all
+
+  tasks:
+    - name: collect facts about system services
+      ansible.builtin.service_facts:
+      register: services_state
+
+    - name: verify Nautobot services are running
+      assert:
+        that: item.state == 'running'
+      with_items:
+        - "{{ services_state.ansible_facts.services['nautobot.service'] }}"
+        - "{{ services_state.ansible_facts.services['nautobot-worker.service'] }}"


### PR DESCRIPTION
Add basic verification step to molecule testing process. This check validates that both the `nautobot` and `nautobot-worker` services are running.