### PR TITLE
Update initial user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ RHEL/CentOS or Ubuntu servers.
 
 ## Requirements
 
-This role manages the installation and configuration of Nautobot. Access to
-remote or local PostgreSQL and Redis instances are required as a dependency of
-the application itself.
+This role manages the installation and configuration of Nautobot. This role
+does not provide PostgreSQL or Redis services that are required dependencies
+of the application. Those tasks are intentionally left to allow the user to 
+manage those services within their own roles and playbooks.
 
-Tested on:
+Tested on Nautobot supported platforms:
 * CentOS 8.2+ or Red Hat Enterprise Linux (RHEL) 8.2+
 * Ubuntu 20.04
 
@@ -20,20 +21,31 @@ on behalf of Nautobot.
 
 ## Role Variables
 
-Minimum required variables assuming `localhost` PostgreSQL and Redis services:
+Minimum required variables assuming `localhost` PostgreSQL and Redis services
+are available:
 
     nautobot_db_username: nautobot
     nautobot_db_password: nautobot
     nautobot_secret_key: "lnvRn_5Bypl8hBV4mMwgsMuHxr6uZvGwJyDqB7fcKqo"
 
-    # Initial user to create during installation
+See [defaults/main.yml](defaults/main.yml) for a complete list of defaults and 
+configurable options.
+
+## User accounts
+
+The following variables can be defined to create users during initial
+installation only:
+
     nautobot_superusers:
       - username: admin
         password: admin
         email: changeme@example.com
 
-See [defaults/main.yml](defaults/main.yml) for a complete list of defaults and 
-configurable options.
+Each user requires a username, password and email address defined. The role will
+attempt to create the defined users only once during initial installation. If 
+`nautobot_superusers` is not defined, no users are created and the manual user
+creation process [documented](https://nautobot.readthedocs.io/en/latest/installation/nautobot/#create-a-superuser)
+by Nautobot can be used instead.
 
 ## Dependencies
 
@@ -52,6 +64,7 @@ None.
     nautobot_db_password: securepass
     nautobot_db_host: postgres.server.url       # omit for default: localhost
     nautobot_redis_host: redis.server.url       # omit for default: localhost
+
     nautobot_superusers:     
       - username: admin                         # initial username
         password: admin                         # initial password

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -78,6 +78,8 @@
 - name: install | check if initial installation of Nautobot
   ansible.builtin.service_facts:
   register: services_state
+  when:
+    - nautobot_superusers is defined
 
 - name: install | create initial Nautobot superusers
   ansible.builtin.shell: nautobot-server createsuperuser --noinput
@@ -102,7 +104,7 @@
     ("CommandError: Error: That username is already taken." not in result.stderr)
   when:
     - nautobot_superusers is defined
-    - services_state.ansible_facts.services['nautobot.service'] is not defined"
+    - services_state.ansible_facts.services['nautobot.service'] is not defined
   tags:
     - skip_ansible_lint # login shell is required to exec as nautobot user with profile
 
@@ -121,7 +123,7 @@
   tags:
     - skip_ansible_lint # login shell is required to exec as nautobot user with profile
 
-- name: install | install python packages specified in local_requirements.txt"
+- name: install | install python packages specified in local_requirements.txt
   ansible.builtin.pip:
     requirements: "{{ nautobot_root }}/local_requirements.txt"
     virtualenv: "{{ nautobot_root }}"


### PR DESCRIPTION
Updated superuser creation to run only once during initial installation and only when `nautobot_superusers` are defined. This allows flexibility in how to create the initial users and ensures users are not being overwritten with subsequent playbook runs.