### PR TITLE
Add Ansible Galaxy release action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master
+  schedule:
+    - cron: "0 22 * * 5"
 
 defaults:
   run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+---
+name: Release
+on:
+  push:
+    tags:
+      - '*'
+
+defaults:
+  run:
+    working-directory: 'jvoss.nautobot'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase
+        uses: actions/checkout@v2
+        with:
+          path: 'jvoss.nautobot'
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install Ansible
+        run: pip3 install ansible-base
+
+      - name: Trigger import on Ansible Galaxy
+        run: ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }} $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)


### PR DESCRIPTION
- Adds a GitHub workflow to trigger releases to Ansible Galaxy when a release is tagged.
- Updated CI workflow to test weekly on Fridays to ensure new Nautobot release continue to install correctly