### PR TITLE
added note about version locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ on behalf of Nautobot.
 Minimum required variables assuming `localhost` PostgreSQL and Redis services
 are available:
 
+    nautobot_version: 1.0.1   # (Optional) Lock to specific Nautobot version
+
     nautobot_db_username: nautobot
     nautobot_db_password: nautobot
     nautobot_secret_key: "lnvRn_5Bypl8hBV4mMwgsMuHxr6uZvGwJyDqB7fcKqo"

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ on behalf of Nautobot.
 Minimum required variables assuming `localhost` PostgreSQL and Redis services
 are available:
 
-    nautobot_version: 1.0.1   # (Optional) Lock to specific Nautobot version
-
     nautobot_db_username: nautobot
     nautobot_db_password: nautobot
     nautobot_secret_key: "lnvRn_5Bypl8hBV4mMwgsMuHxr6uZvGwJyDqB7fcKqo"
@@ -48,6 +46,19 @@ attempt to create the defined users only once during initial installation. If
 `nautobot_superusers` is not defined, no users are created and the manual user
 creation process [documented](https://nautobot.readthedocs.io/en/latest/installation/nautobot/#create-a-superuser)
 by Nautobot can be used instead.
+
+## Version locking
+
+Optionally, a specific version of nautobot can be configured using the variable:
+
+    nautobot_version: 1.0.1
+
+This will ensure that a specific target is maintained. If not set, on initial
+install pip will install the latest version. On subsequent runs it will only check that
+the module is installed but will not upgrade it automatically.
+
+In either case, an upgrade can be triggered by setting this variable to the desired
+Nautobot release version. Downgrading is not supported.
 
 ## Dependencies
 


### PR DESCRIPTION
Added a note about how to lock an installation to a particular version of Nautobot. This flag forces a specific pip release version.