### PR TITLE
added notify hooks to trigger on changes during upgrades

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -52,6 +52,7 @@
     version: "{{ nautobot_version | default('') }}"
     virtualenv: "{{ nautobot_root }}"
     virtualenv_command: python3 -m venv
+  notify: restart_nautobot
   become: yes
   become_user: "{{ nautobot_system_user }}"
 
@@ -68,6 +69,7 @@
   become_method: sudo
   become_flags: --login
   become_user: "{{ nautobot_system_user }}"
+  notify: restart_nautobot
   register: nautobot_db_migration
   changed_when: "'No migrations to apply.' not in nautobot_db_migration.stdout"
   tags:
@@ -129,6 +131,7 @@
     virtualenv: "{{ nautobot_root }}"
     virtualenv_command: python3 -m venv
     state: present
+  notify: restart_nautobot
   become: yes
   become_user: "{{ nautobot_system_user }}"
 


### PR DESCRIPTION
Added notify hooks to trigger Nautobot to restart when its pip package has been upgraded and in other conditions where a restart may be necessary.