### PR TITLE
ensure nautobot system directory has appropriate permissions

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -10,6 +10,14 @@
     state: present
   become: yes
 
+- name: install | ensure Nautobot directory permissions
+  ansible.builtin.file:
+    path: "{{ nautobot_root }}"
+    owner: "{{ nautobot_system_user }}"
+    state: directory
+    mode: '0755'
+  become: yes
+
 - name: install | setup the Nautobot virtual environment
   ansible.builtin.pip:
     name:


### PR DESCRIPTION
Added step to ensure the Nautobot system directory permissions are set to `0755`. This ensures other services accessing the static files at `/opt/nautobot/static` will work. 

This issue appears to come up in RHEL/CentOS when the system user is created. The default home directory permissions were `0700`