### PR TITLE
Remote Header authentication

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,6 +72,10 @@ nautobot_allowed_url_schemes:
   - vnc
   - xmpp
 
+# Authentication backends
+nautobot_authentication_backends:
+  - nautobot.core.authentication.ObjectPermissionBackend
+
 # Optionally display a persistent banner at the top and/or bottom of every page.
 # HTML is allowed. To display the same content in both banners, define
 # BANNER_TOP and set BANNER_BOTTOM = BANNER_TOP.
@@ -227,9 +231,9 @@ nautobot_rack_elevation_default_unit_height: 22
 nautobot_rack_elevation_default_unit_width: 220
 
 # Remote authentication backend support
-nautobot_remote_auth:
-  header: HTTP_REMOTE_USER
-  auto_create_user: False
+# nautobot_remote_auth:
+#  header: HTTP_REMOTE_USER
+#  auto_create_user: False
 
 # This determines how often the GitHub API is called to check the latest release
 # of Nautobot. Timeout must be at least 1 hour.

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,4 +1,16 @@
 ---
+- name: configure | include LDAP in AUTHENTICATION_BACKENDS
+  ansible.builtin.set_fact:
+    nautobot_authentication_backends: |
+      {{ ['django_auth_ldap.backend.LDAPBackend'] + nautobot_authentication_backends }}
+  when: nautobot_auth_ldap is defined
+
+- name: configure | include RemoteUserBackend in AUTHENTICATION_BACKENDS
+  ansible.builtin.set_fact:
+    nautobot_authentication_backends: |
+      {{ ['nautobot.core.authentication.RemoteUserBackend'] + nautobot_authentication_backends }}
+  when: nautobot_remote_auth is defined
+
 - name: configure | configure nautobot_config.py
   ansible.builtin.template:
     src: nautobot_config.py.j2

--- a/templates/nautobot_config.py.j2
+++ b/templates/nautobot_config.py.j2
@@ -96,12 +96,9 @@ ALLOWED_URL_SCHEMES = (
     '{{ nautobot_allowed_url_schemes | join("', '") }}',
 )
 
-{% if nautobot_auth_ldap is defined %}
-AUTHENTICATION_BACKENDS = [
-    'django_auth_ldap.backend.LDAPBackend',
-    'nautobot.core.authentication.ObjectPermissionBackend',
-]
+AUTHENTICATION_BACKENDS = {{ nautobot_authentication_backends | to_nice_json }}
 
+{% if nautobot_auth_ldap is defined %}
 {{ nautobot_auth_ldap.config | default() }}
 {% endif %}
 
@@ -198,8 +195,10 @@ PREFER_IPV4 = {{ nautobot_prefer_ipv4 }}
 RACK_ELEVATION_DEFAULT_UNIT_HEIGHT = {{ nautobot_rack_elevation_default_unit_height }}
 RACK_ELEVATION_DEFAULT_UNIT_WIDTH = {{ nautobot_rack_elevation_default_unit_width }}
 
-REMOTE_AUTH_AUTO_CREATE_USER = {{ nautobot_remote_auth.auto_create_user}}
-REMOTE_AUTH_HEADER = '{{ nautobot_remote_auth.header }}'
+{% if nautobot_remote_auth is defined %}
+REMOTE_AUTH_AUTO_CREATE_USER = {{ nautobot_remote_auth.auto_create_user | default(False) | bool }}
+REMOTE_AUTH_HEADER = '{{ nautobot_remote_auth.header | default('HTTP_REMOTE_USER') }}'
+{% endif %}
 
 RELEASE_CHECK_TIMEOUT = {{ nautobot_release_check.timeout }}
 RELEASE_CHECK_URL = {{ nautobot_release_check.url }}


### PR DESCRIPTION
Added Remote Header authentication configuration and tested with Caddy:

```
caddy_config: |
  :8080 {
    route /static* {
      uri strip_prefix /static
      root * {{ nautobot_root }}/static
      file_server
    }

    reverse_proxy http://127.0.0.1:8001 {
      header_up Remote-User test
    }
  }
```

This change also allows multiple authentication methods to be configured simultaneously.

Resolves #14 